### PR TITLE
Lock the kernel so we align with NCNs

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp2/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp2/config.sh
@@ -55,6 +55,13 @@ echo "Installing packages from /srv/cray/csm-rpms/packages/cray-pre-install-tool
 install-packages /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
 
 #======================================
+# Lock the kernel...
+#--------------------------------------
+uname -r
+rpm -qa kernel-default
+zypper addlock kernel-default
+
+#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct


### PR DESCRIPTION
If/when this merges, we can fast-forward merge into `release/csm-1.1` and then into `main` (@heemstra I rolled back the mistake in `main`).