### PR TITLE
Align function args with csm-shared-library implementation

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -97,9 +97,7 @@ pipeline {
         sh "cp build_output/*.packages build_output/${LATEST_NAME}.packages"
         sh "cp build_output/*.verified build_output/${LATEST_NAME}.verified"
 
-        publishCsmImages(pattern: "build_output/*.iso", imageName: NAME, version: env.VERSION, isStable: isStable, props: "none")
-        publishCsmImages(pattern: "build_output/*.packages", imageName: NAME, version: env.VERSION, isStable: isStable, props: "none")
-        publishCsmImages(pattern: "build_output/*.verified", imageName: NAME, version: env.VERSION, isStable: isStable, props: "none")
+        publishCsmImages(pattern: "build_output/", imageName: NAME, version: env.VERSION, isStable: isStable, props: "none")
       }
     }
   }


### PR DESCRIPTION
There was a mismatch between how we were invoking this function
and how it's defined in the csm-shared-library.  Adjust accordingly.