### PR TITLE
Lock to 1.2 now that we're focusing here

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -44,7 +44,7 @@ pipeline {
   }
 
   parameters {
-    string(name: 'csmRpmRef', defaultValue: "main", description: 'The branch or ref to use when checking out csm-rpm repo for repo list and package lock versions')
+    string(name: 'csmRpmRef', defaultValue: "release/1.2", description: 'The branch or ref to use when checking out csm-rpm repo for repo list and package lock versions')
     string(name: 'nodeLabel', defaultValue: "metal-gcp-builder-large", description: 'Label to build nodes on')
   }
 


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

Locks to csm-rpms/release1.2 manifest.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
