### PR TITLE
MTL-1585 Push latest to the basedir

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -92,12 +92,13 @@ pipeline {
 
     stage('PUBLISH: Transfer Images') {
       steps {
-        // Create a "latest" copy
-        sh "cp build_output/*.iso build_output/${LATEST_NAME}.iso"
-        sh "cp build_output/*.packages build_output/${LATEST_NAME}.packages"
-        sh "cp build_output/*.verified build_output/${LATEST_NAME}.verified"
-
         publishCsmImages(pattern: "build_output/", imageName: NAME, version: env.VERSION, isStable: isStable, props: "none")
+
+        // Create a "latest" copy
+        sh "mv build_output/*.iso build_output/${LATEST_NAME}.iso"
+        sh "mv build_output/*.packages build_output/${LATEST_NAME}.packages"
+        sh "mv build_output/*.verified build_output/${LATEST_NAME}.verified"
+        publishCsmImages(pattern: "build_output/", imageName: NAME, version: 'latest', isStable: isStable, props: "none")
       }
     }
   }


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1585

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

This pushes the latest ISO into a non-versioned directory on Artifactory.

Links will work after this PR's build is green, the stable link won't work until this is merged.
- unstable: https://artifactory.algol60.net/artifactory/csm-images/unstable/cray-pre-install-toolkit/latest 
- stable: https://artifactory.algol60.net/artifactory/csm-images/unstable/cray-pre-install-toolkit/latest

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?
