### PR TITLE
CASMINST-4249 enable conman service

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 #================
 # FILE          : config.sh
 #----------------
@@ -78,6 +101,7 @@ suseSetupProduct
 #--------------------------------------
 suseInsertService apache2
 suseInsertService basecamp
+suseInsertService conman
 suseInsertService chronyd
 suseInsertService dnsmasq
 suseInsertService nexus


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

#### Summary and Scope

- Fixes # CASMINST-4249
- Merge with https://github.com/Cray-HPE/node-image-build/pull/211

##### Issue Type

- Bugfix Pull Request

Enables conman service to pass failing GOSS test.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low.
