### PR TITLE
Use new --pit argument for setup-package-repos invocation

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
@@ -47,7 +47,7 @@ echo "Sourcing /srv/cray/csm-rpms/scripts/rpm-functions.sh"
 echo "Setting up package repos from rpm-functions"
 # Remove base bootstrap repos in favor of csm-rpm defined repos
 cleanup-all-repos
-setup-package-repos
+setup-package-repos --pit
 
 #======================================
 # Install Packages...


### PR DESCRIPTION
#### Summary and Scope

Use the new --pit argument for setup-package-repos so that we have
more control over which repos we are configuring.

Pairs with: https://github.com/Cray-HPE/csm-rpms/pull/351