### PR TITLE
Point to main

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -44,7 +44,7 @@ pipeline {
   }
 
   parameters {
-    string(name: 'csmRpmRef', defaultValue: "release/1.2", description: 'The branch or ref to use when checking out csm-rpm repo for repo list and package lock versions')
+    string(name: 'csmRpmRef', defaultValue: "main", description: 'The branch or ref to use when checking out csm-rpm repo for repo list and package lock versions')
     string(name: 'nodeLabel', defaultValue: "metal-gcp-builder-large", description: 'Label to build nodes on')
   }
 


### PR DESCRIPTION
Update `main` to point to CSM-RPMs `main` for 1.3.0 builds.