### PR TITLE
MTL-1612 Enable pressure stats

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp2/config.xml
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp2/config.xml
@@ -29,7 +29,7 @@ WARNING: Please consult the README.md file in the top level directory of
               devicepersistency="by-label"
               publisher="CRAY-HPE"
               volid="CRAYLIVE"
-              kernelcmdline="payload=file://dev/sda3 splash=silent mediacheck=0 biosdevname=1 console=tty0 console=ttyS0,115200 mitigations=auto iommu=pt pcie_ports=native transparent_hugepage=never rd.shell rd.md=0 rd.md.conf=0"
+              kernelcmdline="payload=file://dev/sda3 splash=silent mediacheck=0 biosdevname=1 psi=1 console=tty0 console=ttyS0,115200 mitigations=auto iommu=pt pcie_ports=native transparent_hugepage=never rd.shell rd.md=0 rd.md.conf=0"
               mediacheck="true"/>
         <version>CRAY.VERSION.HERE</version>
         <packagemanager>zypper</packagemanager>

--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.template.xml
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.template.xml
@@ -29,7 +29,7 @@ WARNING: Please consult the README.md file in the top level directory of
               devicepersistency="by-label"
               publisher="CRAY-HPE"
               volid="CRAYLIVE"
-              kernelcmdline="payload=file://dev/sda3 splash=silent mediacheck=0 biosdevname=1 console=tty0 console=ttyS0,115200 mitigations=auto iommu=pt pcie_ports=native transparent_hugepage=never rd.shell rd.md=0 rd.md.conf=0"
+              kernelcmdline="payload=file://dev/sda3 splash=silent mediacheck=0 biosdevname=1 psi=1 console=tty0 console=ttyS0,115200 mitigations=auto iommu=pt pcie_ports=native transparent_hugepage=never rd.shell rd.md=0 rd.md.conf=0"
               mediacheck="true"/>
         <version>CRAY.VERSION.HERE</version>
         <packagemanager>zypper</packagemanager>

--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.template.xml
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.template.xml
@@ -29,7 +29,7 @@ WARNING: Please consult the README.md file in the top level directory of
               devicepersistency="by-label"
               publisher="CRAY-HPE"
               volid="CRAYLIVE"
-              kernelcmdline="payload=file://dev/sda3 splash=silent mediacheck=0 biosdevname=1 console=tty0 console=ttyS0,115200 mitigations=auto iommu=pt pcie_ports=native transparent_hugepage=never rd.shell rd.md=0 rd.md.conf=0"
+              kernelcmdline="payload=file://dev/sda3 splash=silent mediacheck=0 biosdevname=1 psi=1 console=tty0 console=ttyS0,115200 mitigations=auto iommu=pt pcie_ports=native transparent_hugepage=never rd.shell rd.md=0 rd.md.conf=0"
               mediacheck="true"/>
         <version>CRAY.VERSION.HERE</version>
         <packagemanager>zypper</packagemanager>


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1612

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Pressure stats are disabled by default, and can be enabled by passing `psi=1` on the cmdline. This enables reading the `/proc/pressure/{cpu,io,memory}` handles.

By default pressure stats are disabled do to the feature flag `CONFIG_PSI_DEFAULT_DISABLED` in our distributions kernel. `psi=1` enables them despite the flag.

More information can be found here: https://facebookmicrosites.github.io/psi/docs/overview.html


This is only semi-useful on the LiveCD, but it is being enabled here for consistency.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
Before adding `psi=1`:

```bash
ncn-w002:~ # cat /proc/pressure/{cpu,io,memory}
cat: /proc/pressure/cpu: Operation not supported
cat: /proc/pressure/io: Operation not supported
cat: /proc/pressure/memory: Operation not supported
```

After adding `psi=1`:

```bash
ncn-w002:~ # cat /proc/pressure/{cpu,io,memory}
some avg10=0.00 avg60=0.00 avg300=0.00 total=592569
some avg10=0.00 avg60=0.00 avg300=0.00 total=40666
full avg10=0.00 avg60=0.00 avg300=0.00 total=38245
some avg10=0.00 avg60=0.00 avg300=0.00 total=0
full avg10=0.00 avg60=0.00 avg300=0.00 total=0
```

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
