### PR TITLE
Fix timestamps in `PIT_SLUG`

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -30,18 +30,8 @@ pipeline {
   }
 
   stages {
-    stage('PREP: ISO NAME') {
-      environment {
-        PIT_SLUG = "${env.VERSION}-${env.BUILD_DATE}"
-      }
-      steps {
-        script {
-          echo "${env.GIT_REPO_NAME}-${env.TARGET_OS.replaceAll('-', '')}.${env.ARCH}-${env.PIT_SLUG}.iso"
-        }
-      }
-    }
 
-    stage('Checkout csm-rpms') {
+    stage('Prep: Checkout csm-rpms') {
       steps {
         dir('suse/x86_64/cray-pre-install-toolkit-sle15sp3/root/srv/cray/csm-rpms') {
            git credentialsId: 'jenkins-algol60-cray-hpe-github-integration', url: 'https://github.com/Cray-HPE/csm-rpms.git', branch: params.csmRpmRef
@@ -49,15 +39,13 @@ pipeline {
       }
     }
 
-    stage('BUILD: Build Image') {
+    stage('Build: Image') {
+      environment {
+        PIT_SLUG = "${env.VERSION}-${env.BUILD_DATE}"
+      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-          // Run the build script. It will ensure
-          // any cached docker image is removed so
-          // the latest is pulled. The output of the
-          // build will be copied to the 'build_output'
-          // subdirectory.
-
+          echo "${env.GIT_REPO_NAME}-${env.TARGET_OS.replaceAll('-', '')}.${env.ARCH}-${env.PIT_SLUG}.iso"
           sh '''
               ARTIFACTORY_USER=${ARTIFACTORY_USER} \
               ARTIFACTORY_TOKEN=${ARTIFACTORY_TOKEN} \
@@ -67,7 +55,7 @@ pipeline {
       }
     }
 
-    stage('PUBLISH: Transfer Images') {
+    stage('Publish: Images') {
       steps {
         publishCsmImages(pattern: "build_output/", imageName: env.GIT_REPO_NAME, version: env.VERSION, isStable: isStable, props: "none")
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: Timestamp for the ISO in the build output

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`PIT_SLUG` was only defined during the prepare stage, since it wasn't being set during the build stage a new timestamp was being generated. This mean that the ISO name that printed at the beginning of the build was incorrect. The ISO name that prints at the beginning is a maintainer helper, so the developer/maintainer can see the ISO name before the ISO is finished. If this is wrong then it is misleading.
For example, users may update `csm/assets.sh` prior to the ISO finishing a build but if they use the name printed off in the console then the ISO's final name will mismatch and `assets.sh` will be wrong.

Example:

```
# Printed at the start of the build:
14:30:53  cray-pre-install-toolkit-sle15sp3.x86_64-1.8.4-20220719193052.iso

# Actual ISO name:
cray-pre-install-toolkit-sle15sp3.x86_64-1.8.4-20220719193055.iso
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
