### PR TITLE
MTL-1910 Inherit from NCN

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
@@ -67,12 +67,28 @@ setup-package-repos --pit
 
 #======================================
 # Install Packages...
+# This repo makes metal (hardware) artifacts
+# therefore only base and metal .package files 
+# are referenced.
 #--------------------------------------
-echo "Installing packages from /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/base.packages"
-install-packages /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-common/base.packages
 
-echo "Installing packages from /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/metal.packages"
-install-packages /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-common/metal.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages
+
+#======================================
+# Setup apparmor for dnsmasq
+# TODO: Move this into the metal-ipxe.spec file.
+# NOTE: editing local/usr.sbin.dnsmasq 
+# apparmor profile does not work
+#--------------------------------------
+echo 'Adding `/var/www/boot` to apparmor for dnsmasq'
+sed -i -E 's/(@\{TFTP_DIR\}=.*)/\1 \/var\/www\/boot/g' /etc/apparmor.d/usr.sbin.dnsmasq
+rm -fv /etc/dnsmasq.conf.rpmnew
 
 #======================================
 # Setup Python3 environments.

--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.sh
@@ -67,12 +67,28 @@ setup-package-repos --pit
 
 #======================================
 # Install Packages...
+# This repo makes metal (hardware) artifacts
+# therefore only base and metal .package files 
+# are referenced.
 #--------------------------------------
-echo "Installing packages from /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/base.packages"
-install-packages /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-common/base.packages
 
-echo "Installing packages from /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/metal.packages"
-install-packages /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-common/metal.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages
+
+#======================================
+# Setup apparmor for dnsmasq
+# TODO: Move this into the metal-ipxe.spec file.
+# NOTE: editing local/usr.sbin.dnsmasq 
+# apparmor profile does not work
+#--------------------------------------
+echo 'Adding `/var/www/boot` to apparmor for dnsmasq'
+sed -i -E 's/(@\{TFTP_DIR\}=.*)/\1 \/var\/www\/boot/g' /etc/apparmor.d/usr.sbin.dnsmasq
+rm -fv /etc/dnsmasq.conf.rpmnew
 
 #======================================
 # Setup Python3 environments.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1910
- Requires: https://github.com/Cray-HPE/csm-rpms/pull/557
- Relates to: https://github.com/Cray-HPE/node-images/pull/464

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This brings in the NCN Common packages into the SP3 and SP4 builds since csm-rpms has been reorganized to cease duplicate package listings between the PIT and NCN.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
