### PR TITLE
CASMINST-4637: remove SUSEConnect entries from /etc/containers/mounts.conf

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
@@ -141,6 +141,12 @@ zypper --verbose clean --all
 rm -r /etc/zypp/repos.d/*
 cp /dev/null /var/log/zypper.log
 
+#=========================================
+# Purge SUSEConnect lines from mounts.conf
+#-----------------------------------------
+# remove all lines that start with '/', leaving the informational comment header intact
+test -f /etc/containers/mounts.conf && sed -i '/^\//d' /etc/containers/mounts.conf
+
 #======================================
 # Set hostname to pit
 #--------------------------------------

--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.sh
@@ -141,6 +141,12 @@ zypper --verbose clean --all
 rm -r /etc/zypp/repos.d/*
 cp /dev/null /var/log/zypper.log
 
+#=========================================
+# Purge SUSEConnect lines from mounts.conf
+#-----------------------------------------
+# remove all lines that start with '/', leaving the informational comment header intact
+test -f /etc/containers/mounts.conf && sed -i '/^\//d' /etc/containers/mounts.conf
+
 #======================================
 # Set hostname to pit
 #--------------------------------------


### PR DESCRIPTION
### Summary and Scope

Remove everything except the comment header from from /etc/containers/mounts.conf.
The existing entries point paths that do not exist.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-4637

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
