### PR TITLE
MTL-2034 Use new `node-images-base` package list

### DIFF
--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.sh
@@ -71,11 +71,23 @@ setup-package-repos --pit
 # therefore only base and metal .package files 
 # are referenced.
 #--------------------------------------
-echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/base.packages"
-install-packages /srv/cray/csm-rpms/packages/node-image-common/base.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/base.packages
 
-echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/metal.packages"
-install-packages /srv/cray/csm-rpms/packages/node-image-common/metal.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/metal.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/base.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/metal.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-ncn-common/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-ncn-common/base.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-ncn-common/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-ncn-common/metal.packages
 
 echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages"
 install-packages /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages

--- a/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.sh
+++ b/suse/x86_64/cray-pre-install-toolkit-sle15sp4/config.sh
@@ -71,11 +71,23 @@ setup-package-repos --pit
 # therefore only base and metal .package files 
 # are referenced.
 #--------------------------------------
-echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/base.packages"
-install-packages /srv/cray/csm-rpms/packages/node-image-common/base.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/base.packages
 
-echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-common/metal.packages"
-install-packages /srv/cray/csm-rpms/packages/node-image-common/metal.packages
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/metal.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/base.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-base/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-base/metal.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-ncn-common/base.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-ncn-common/base.packages
+
+echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-ncn-common/metal.packages"
+install-packages /srv/cray/csm-rpms/packages/node-image-ncn-common/metal.packages
 
 echo "Installing packages from /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages"
 install-packages /srv/cray/csm-rpms/packages/node-image-pre-install-toolkit/base.packages


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2034
- Requires: https://github.com/Cray-HPE/csm-rpms/pull/657
- Relates to: https://github.com/Cray-HPE/node-images/pull/573

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Incorporates the new broken-out `node-images-base` package list.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
